### PR TITLE
Parse presentation from yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ dependencies = [
  "said",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempdir",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ oca-ast = { version = "0.4.1-rc.6"}
 oca-bundle = { version = "0.4.1-rc.6" }
 recursion = "0.5.2"
 itertools = "0.12.0"
+serde_yaml = "0.9.30"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,4 +22,8 @@ pub enum CliError {
     ReadOcaError(serde_json::error::Error),
     #[error("Field to read oca bundle: {0}")]
     WriteOcaError(serde_json::error::Error),
+    #[error("Unsupported format {0}")]
+    FormatError(String),
+    #[error("Unsupported extension format {0}")]
+    FileExtensionError(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -461,7 +461,9 @@ fn main() -> Result<(), CliError> {
                     let facade = get_oca_facade(local_repository_path);
                     let presentation = handle_generate(said, &facade)?;
                     let output = match format {
-                        Some(Format::JSON) | None => serde_json::to_string_pretty(&presentation).unwrap(),
+                        Some(Format::JSON) | None => {
+                            serde_json::to_string_pretty(&presentation).unwrap()
+                        }
                         Some(Format::YAML) => serde_yaml::to_string(&presentation).unwrap(),
                     };
                     println!("{}", output);
@@ -475,14 +477,17 @@ fn main() -> Result<(), CliError> {
                     let ext = from_file.extension();
                     let extension = match ext {
                         Some(ext) => match ext.to_str() {
-                            Some(ext) => Format::from_str(ext).map_err(|e| CliError::FileExtensionError(e.to_string())),
-                            None => Err(CliError::FileExtensionError("Unsupported file extension".to_string())),
+                            Some(ext) => Format::from_str(ext)
+                                .map_err(|e| CliError::FileExtensionError(e.to_string())),
+                            None => Err(CliError::FileExtensionError(
+                                "Unsupported file extension".to_string(),
+                            )),
                         },
                         None => {
                             // CliError::ExtensionError("Missing file extension".to_string())
                             warn!("Missing input file extension. Using JSON");
                             Ok(Format::JSON)
-                        },
+                        }
                     }?;
 
                     let file_contents =

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use error::CliError;
+use presentation_command::PresentationCommand;
 use std::env;
 use std::fs;
 use std::fs::File;
@@ -111,30 +112,11 @@ enum Commands {
     },
 }
 
-#[derive(Subcommand)]
-enum PresentationCommand {
-    /// Generate presentation for OCA bundle of provided SAID
-    Generate {
-        /// SAID of OCA Bundle
-        #[arg(short, long)]
-        said: String,
-    },
-    /// Parse presentation from file. If `d` field is empty, it computes
-    /// presentation SAID and put it into `d` field
-    Parse {
-        /// Path to input file
-        #[arg(short, long)]
-        from_file: PathBuf,
-        /// Path to output file
-        #[arg(short, long)]
-        output: Option<PathBuf>,
-    },
-}
-
 use std::io::Error;
 
 use crate::presentation_command::handle_generate;
 use crate::presentation_command::handle_parse;
+use crate::presentation_command::Format;
 
 fn read_config(path: &PathBuf) -> Result<Config, Error> {
     let content = fs::read_to_string(path)?;
@@ -474,17 +456,38 @@ fn main() -> Result<(), CliError> {
         }
         Some(Commands::Presentation { command }) => {
             match command {
-                PresentationCommand::Generate { said } => {
+                PresentationCommand::Generate { said, format } => {
                     let said = SelfAddressingIdentifier::from_str(said)?;
                     let facade = get_oca_facade(local_repository_path);
                     let presentation = handle_generate(said, &facade)?;
-                    println!("{}", serde_json::to_string_pretty(&presentation).unwrap());
+                    let output = match format {
+                        Some(Format::JSON) | None => serde_json::to_string_pretty(&presentation).unwrap(),
+                        Some(Format::YAML) => serde_yaml::to_string(&presentation).unwrap(),
+                    };
+                    println!("{}", output);
                     Ok(())
                 }
-                PresentationCommand::Parse { from_file, output } => {
+                PresentationCommand::Parse {
+                    from_file,
+                    output,
+                    format,
+                } => {
+                    let ext = from_file.extension();
+                    let extension = match ext {
+                        Some(ext) => match ext.to_str() {
+                            Some(ext) => Format::from_str(ext).map_err(|e| CliError::FileExtensionError(e.to_string())),
+                            None => Err(CliError::FileExtensionError("Unsupported file extension".to_string())),
+                        },
+                        None => {
+                            // CliError::ExtensionError("Missing file extension".to_string())
+                            warn!("Missing input file extension. Using JSON");
+                            Ok(Format::JSON)
+                        },
+                    }?;
+
                     let file_contents =
                         fs::read_to_string(from_file).map_err(CliError::ReadFileFailed)?;
-                    let pres = handle_parse(&file_contents)?;
+                    let pres = handle_parse(&file_contents, extension)?;
                     // save to file
                     let out_path = if let Some(out) = output {
                         out
@@ -492,7 +495,11 @@ fn main() -> Result<(), CliError> {
                         from_file
                     };
                     let mut file = File::create(out_path).map_err(CliError::WriteFileFailed)?;
-                    file.write_all(serde_json::to_string_pretty(&pres).unwrap().as_bytes())
+                    let output = match format {
+                        Some(Format::JSON) | None => serde_json::to_string_pretty(&pres).unwrap(),
+                        Some(Format::YAML) => serde_yaml::to_string(&pres).unwrap(),
+                    };
+                    file.write_all(output.as_bytes())
                         .map_err(CliError::WriteFileFailed)?;
                     Ok(())
                 }

--- a/src/presentation_command.rs
+++ b/src/presentation_command.rs
@@ -134,7 +134,6 @@ pub fn handle_generate(
         .unique()
         .collect();
 
-
     let mut pages_labels = indexmap::IndexMap::new();
     for overlay in bundle.overlays {
         match overlay.overlay_type() {
@@ -147,7 +146,7 @@ pub fn handle_generate(
                 let pages_label: BTreeMap<String, String> =
                     label.clone().attribute_labels.into_iter().collect();
 
-                pages_labels.insert(label.language().unwrap().clone(), pages_label);
+                pages_labels.insert(*label.language().unwrap(), pages_label);
             }
             _ => {}
         }
@@ -417,11 +416,11 @@ ADD ENTRY pl ATTRS radio={"o1": "etykieta1", "o2": "etykieta2", "o3": "etykieta3
             vec![Language::Epo, Language::Pol, Language::Eng]
         );
         let translations = &presentation.pages_label;
-        let epo_expected: BTreeMap<String, String> = serde_json::from_str(r#"{"age": "aĝo","name": "Nomo","radio": "radio"}"#)
-            .unwrap();
+        let epo_expected: BTreeMap<String, String> =
+            serde_json::from_str(r#"{"age": "aĝo","name": "Nomo","radio": "radio"}"#).unwrap();
 
-        let pol_expected: BTreeMap<String, String> = serde_json::from_str(r#"{"age": "wiek","name": "Imię","radio": "radio"}"#)
-            .unwrap();
+        let pol_expected: BTreeMap<String, String> =
+            serde_json::from_str(r#"{"age": "wiek","name": "Imię","radio": "radio"}"#).unwrap();
         assert_eq!(translations.get(&Language::Epo).unwrap(), &epo_expected);
         assert_eq!(translations.get(&Language::Pol).unwrap(), &pol_expected);
 


### PR DESCRIPTION
Changes:
- add yaml format support for presentation,
- change `parse` sub command to `validate`. Add `-r` option for recomputing SAID,
- update presentation generation: extend `pl` section with languages from labels and `i` section with attributes properties.